### PR TITLE
Remove use of `String.prototype.at`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@exact-realty/lot",
-	"version": "0.0.20",
+	"version": "0.0.21",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@exact-realty/lot",
-			"version": "0.0.20",
+			"version": "0.0.21",
 			"license": "ISC",
 			"devDependencies": {
 				"@exact-realty/esbuild-plugin-closure-compiler": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@exact-realty/lot",
-	"version": "0.0.20",
+	"version": "0.0.21",
 	"description": "Sandbox for isolating ECMAScript code",
 	"main": "dist/index.cjs",
 	"types": "dist/index.d.cts",

--- a/src/untrusted/lib/hardenGlobals.ts
+++ b/src/untrusted/lib/hardenGlobals.ts
@@ -210,13 +210,15 @@ const disableURLStaticMethods = () => {
 				['writable']: true,
 				['enumerable']: true,
 				['configurable']: true,
-				['value']: String.bind(null),
+				['value']: function () {
+					return '';
+				}.bind(null),
 			},
 			['revokeObjectURL']: {
 				['writable']: true,
 				['enumerable']: true,
 				['configurable']: true,
-				['value']: String.prototype.at.bind(''),
+				['value']: function () {}.bind(null),
 			},
 		});
 };


### PR DESCRIPTION
This fixes an issue in Konqueror and Falkon, where `String.prototype.at` is not defined.

Also: Update examples